### PR TITLE
Python 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The operations increment or decrement do not use the parameter start. Scrapy has
     ```
     pip install scrapy-statsd
    ```
-   _Note: The requirements state Scrapy version 1.0.5 but that'll be reduce once testing is done._
+   _Note: The requirements state Scrapy version 1.0.5 or higher, but that'll be reduce once testing is done._
 
 1. Add the following lines to your `settings.py` of your Scrapy project 
 

--- a/scrapy_statsd/statscollectors.py
+++ b/scrapy_statsd/statscollectors.py
@@ -1,6 +1,7 @@
 from twisted.internet.threads import deferToThread
 import scrapy.statscollectors
 import statsd
+import six
 
 class StatsDStatsCollector(scrapy.statscollectors.MemoryStatsCollector):
     """
@@ -18,11 +19,7 @@ class StatsDStatsCollector(scrapy.statscollectors.MemoryStatsCollector):
     ever set.
     """
 
-    NUMERIC_TYPES = [
-        int,
-        float,
-        long
-    ]
+    NUMERIC_TYPES = six.integer_types + (float,)
 
     def __init__(self, crawler):
         super(StatsDStatsCollector, self).__init__(crawler)

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,13 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     keywords='scrapy stats',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     install_requires=[
+        'six',
         'Scrapy>=1.0.5',
         'statsd==3.2.1'
     ],


### PR DESCRIPTION
There was only a tiny detail missing from python 3 support: there is no `long` type in python 3. I added `six` dependency - it's already used by scrapy.
